### PR TITLE
ENH: Adding in balance plot

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@
 omit =
     */tests*
     */__init__.py
+    */gneiss/layouts.py
 source = gneiss
 branch = True
 include = */gneiss/*
@@ -16,3 +17,4 @@ exclude_lines =
 omit =
     */tests*
     */__init__.py
+    */gneiss/layouts.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+# this file is based on the examples provided on scikit-learn's .coveragerc
+
+[run]
+omit =
+    */tests*
+    */__init__.py
+source = gneiss
+branch = True
+include = */gneiss/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+omit =
+    */tests*
+    */__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   # Update conda itself
   - conda update --yes conda
   # Useful for debugging any issues with conda
+  - conda info -a
 install:
   - conda create --yes -n test_env python=$PYVERSION --file ci/conda_requirements.txt -c biocore
   - conda install --yes -n test_env cython
@@ -21,7 +22,9 @@ install:
   - pip install -r ci/pip_requirements.txt
   - pip install -e .
 script:
-  - make all
+  - WITH_COVERAGE=TRUE make all
+after_success:
+  - coveralls
 notifications:
   webhooks:
     on_success: change

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .DEFAULT_GOAL := help
 
-TEST_COMMAND = nosetests --with-doctest
+ifeq ($(WITH_COVERAGE), TRUE)
+	TEST_COMMAND = COVERAGE_FILE=.coverage coverage run --rcfile .coveragerc setup.py nosetests --with-doctest
+else
+	TEST_COMMAND = nosetests --with-doctest
+endif
 
 help:
 	@echo 'Use "make test" to run all the unit tests and docstring tests.'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [[https://coveralls.io/github/biocore/gneiss?branch=master][https://coveralls.io/repos/biocore/gneiss/badge.svg?branch=master&service=github]]
-[[https://travis-ci.org/biocore/gneiss][https://travis-ci.org/biocore/micronota.svg?branch=master]]
+[[https://travis-ci.org/biocore/gneiss][https://travis-ci.org/biocore/gneiss.svg?branch=master]]
 
 Canonically pronouced *nice*
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # gneiss
 
+
+[[https://coveralls.io/github/biocore/micronota?branch=master][https://coveralls.io/repos/biocore/micronota/badge.svg?branch=master&service=github]]
+[[https://travis-ci.org/biocore/micronota][https://travis-ci.org/biocore/micronota.svg?branch=master]]
+
 Canonically pronouced *nice*
 
 A compositional statistics and visualization toolbox

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # gneiss
 
 
-[[https://coveralls.io/github/biocore/micronota?branch=master][https://coveralls.io/repos/biocore/micronota/badge.svg?branch=master&service=github]]
-[[https://travis-ci.org/biocore/micronota][https://travis-ci.org/biocore/micronota.svg?branch=master]]
+[[https://coveralls.io/github/biocore/gneiss?branch=master][https://coveralls.io/repos/biocore/gneiss/badge.svg?branch=master&service=github]]
+[[https://travis-ci.org/biocore/gneiss][https://travis-ci.org/biocore/micronota.svg?branch=master]]
 
 Canonically pronouced *nice*
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # gneiss
 
-
-[[https://coveralls.io/github/biocore/gneiss?branch=master][https://coveralls.io/repos/biocore/gneiss/badge.svg?branch=master&service=github]]
-[[https://travis-ci.org/biocore/gneiss][https://travis-ci.org/biocore/gneiss.svg?branch=master]]
+[![Build Status](https://travis-ci.org/biocore/gneiss.png?branch=master)](https://travis-ci.org/biocore/gneiss)
+[![Coverage Status](https://coveralls.io/repos/biocore/gneiss/badge.svg)](https://coveralls.io/r/biocore/gneiss)
 
 Canonically pronouced *nice*
 

--- a/gneiss/balances.py
+++ b/gneiss/balances.py
@@ -2,6 +2,7 @@ from __future__ import division
 import numpy as np
 from skbio.stats.composition import clr_inv
 from collections import OrderedDict
+from ete3 import Tree, TreeStyle, faces, AttrFace, CircleFace, BarChartFace
 
 
 def _balance_basis(tree_node):

--- a/gneiss/balances.py
+++ b/gneiss/balances.py
@@ -134,6 +134,14 @@ def _count_matrix(treenode):
 
 
 def default_layout(node):
+    """
+    Specifies the layout for the ete.TreeStyle object.
+
+    Parameters
+    ----------
+    node: ete.Tree
+        Input node for specifying which attributes.
+    """
     if node.is_leaf():
         # Add node name to leaf nodes
         N = AttrFace("name", fsize=14, fgcolor="black")
@@ -157,6 +165,34 @@ def barchart_layout(node, name='name',
                     fsize=14, fgcolor="black",
                     alpha=0.5,
                     rotation=270):
+    """
+    Specifies the layout for the ete.TreeStyle object.
+
+    Parameters
+    ----------
+    node: ete.Tree
+        Input node for specifying which attributes.
+    name: str, optional
+        Attribute to look up the name of the node.
+    width: int, optional
+        Width of the barchart.
+    height: int, optional
+        Height of the barchart.
+    colors: list of str, optional
+        List of HTML colors to color the barchart values.
+    min_value: int, optional
+        Minimum value to set the scale of the chart.
+    max_value: int, optional
+        Maximum value to set the scale of the chart.
+    fsize: int, optional
+        Font size on the leafs.
+    fgcolor: str, optional
+        Font color of the leafs.
+    alpha: float, optional
+        Transparency of the barchart.
+    rotation: int, optional
+        Orientation of the barchart.
+    """
     if colors is None:
         colors = ['#0000FF']
     if node.is_leaf():
@@ -172,7 +208,7 @@ def barchart_layout(node, name='name',
         else:
             weight = node.weight
         C = BarChartFace(values=weight, width=width, height=height,
-                         colors=['#0000FF'], min_value=min_value,
+                         colors=colors, min_value=min_value,
                          max_value=max_value)
         # Let's make the sphere transparent
         C.opacity = alpha
@@ -269,7 +305,7 @@ def balanceplot(balances, tree,
 
     See Also
     --------
-    TreeNode.levelorder
+    skbio.TreeNode.levelorder
     """
     ete_tree = _attach_balances(balances, tree)
 

--- a/gneiss/balances.py
+++ b/gneiss/balances.py
@@ -3,7 +3,8 @@ import numpy as np
 import pandas as pd
 from skbio.stats.composition import clr_inv
 from collections import OrderedDict
-from ete3 import Tree, TreeStyle, faces, AttrFace, CircleFace, BarChartFace
+from ete3 import Tree, TreeStyle
+from gneiss.layouts import default_layout
 
 
 def _balance_basis(tree_node):
@@ -131,91 +132,6 @@ def _count_matrix(treenode):
             counts[n]['k'] = counts[n.parent]['k'] + counts[n.parent]['r']
             counts[n]['t'] = counts[n.parent]['t']
     return counts, n_tips
-
-
-def default_layout(node):
-    """
-    Specifies the layout for the ete.TreeStyle object.
-
-    Parameters
-    ----------
-    node: ete.Tree
-        Input node for specifying which attributes.
-    """
-    if node.is_leaf():
-        # Add node name to leaf nodes
-        N = AttrFace("name", fsize=14, fgcolor="black")
-
-        faces.add_face_to_node(N, node, 0)
-    if "weight" in node.features:
-        # Creates a sphere face whose size is proportional to node's
-        # feature "weight"
-        C = CircleFace(radius=node.weight, color="Red", style="sphere")
-        # Let's make the sphere transparent
-        C.opacity = 0.5
-        # Rotate the faces by 90*
-        C.rotation = 90
-        # And place as a float face over the tree
-        faces.add_face_to_node(C, node, 0, position="float")
-
-
-def barchart_layout(node, name='name',
-                    width=20, height=40,
-                    colors=None, min_value=0, max_value=1,
-                    fsize=14, fgcolor="black",
-                    alpha=0.5,
-                    rotation=270):
-    """
-    Specifies the layout for the ete.TreeStyle object.
-
-    Parameters
-    ----------
-    node: ete.Tree
-        Input node for specifying which attributes.
-    name: str, optional
-        Attribute to look up the name of the node.
-    width: int, optional
-        Width of the barchart.
-    height: int, optional
-        Height of the barchart.
-    colors: list of str, optional
-        List of HTML colors to color the barchart values.
-    min_value: int, optional
-        Minimum value to set the scale of the chart.
-    max_value: int, optional
-        Maximum value to set the scale of the chart.
-    fsize: int, optional
-        Font size on the leafs.
-    fgcolor: str, optional
-        Font color of the leafs.
-    alpha: float, optional
-        Transparency of the barchart.
-    rotation: int, optional
-        Orientation of the barchart.
-    """
-    if colors is None:
-        colors = ['#0000FF']
-    if node.is_leaf():
-        # Add node name to leaf nodes
-        N = AttrFace("name", fsize=fsize, fgcolor=fgcolor)
-
-        faces.add_face_to_node(N, node, 0)
-    if "weight" in node.features:
-        # Creates a sphere face whose size is proportional to node's
-        # feature "weight"
-        if (isinstance(node.weight, int) or isinstance(node.weight, float)):
-            weight = [node.weight]
-        else:
-            weight = node.weight
-        C = BarChartFace(values=weight, width=width, height=height,
-                         colors=colors, min_value=min_value,
-                         max_value=max_value)
-        # Let's make the sphere transparent
-        C.opacity = alpha
-        # Rotate the faces by 270*
-        C.rotation = rotation
-        # And place as a float face over the tree
-        faces.add_face_to_node(C, node, 0, position="float")
 
 
 def _attach_balances(balances, tree):

--- a/gneiss/layouts.py
+++ b/gneiss/layouts.py
@@ -1,0 +1,86 @@
+from ete3 import faces, AttrFace, CircleFace, BarChartFace
+
+
+def default_layout(node):
+    """
+    Specifies the layout for the ete.TreeStyle object.
+
+    Parameters
+    ----------
+    node: ete.Tree
+        Input node for specifying which attributes.
+    """
+    if node.is_leaf():
+        # Add node name to leaf nodes
+        N = AttrFace("name", fsize=14, fgcolor="black")
+
+        faces.add_face_to_node(N, node, 0)
+    if "weight" in node.features:
+        # Creates a sphere face whose size is proportional to node's
+        # feature "weight"
+        C = CircleFace(radius=node.weight, color="Red", style="sphere")
+        # Let's make the sphere transparent
+        C.opacity = 0.5
+        # Rotate the faces by 90*
+        C.rotation = 90
+        # And place as a float face over the tree
+        faces.add_face_to_node(C, node, 0, position="float")
+
+
+def barchart_layout(node, name='name',
+                    width=20, height=40,
+                    colors=None, min_value=0, max_value=1,
+                    fsize=14, fgcolor="black",
+                    alpha=0.5,
+                    rotation=270):
+    """
+    Specifies the layout for the ete.TreeStyle object.
+
+    Parameters
+    ----------
+    node: ete.Tree
+        Input node for specifying which attributes.
+    name: str, optional
+        Attribute to look up the name of the node.
+    width: int, optional
+        Width of the barchart.
+    height: int, optional
+        Height of the barchart.
+    colors: list of str, optional
+        List of HTML colors to color the barchart values.
+    min_value: int, optional
+        Minimum value to set the scale of the chart.
+    max_value: int, optional
+        Maximum value to set the scale of the chart.
+    fsize: int, optional
+        Font size on the leafs.
+    fgcolor: str, optional
+        Font color of the leafs.
+    alpha: float, optional
+        Transparency of the barchart.
+    rotation: int, optional
+        Orientation of the barchart.
+    """
+    if colors is None:
+        colors = ['#0000FF']
+    if node.is_leaf():
+        # Add node name to leaf nodes
+        N = AttrFace("name", fsize=fsize, fgcolor=fgcolor)
+
+        faces.add_face_to_node(N, node, 0)
+    if "weight" in node.features:
+        # Creates a sphere face whose size is proportional to node's
+        # feature "weight"
+        if (isinstance(node.weight, int) or isinstance(node.weight, float)):
+            weight = [node.weight]
+        else:
+            weight = node.weight
+        C = BarChartFace(values=weight, width=width, height=height,
+                         colors=colors, min_value=min_value,
+                         max_value=max_value)
+        # Let's make the sphere transparent
+        C.opacity = alpha
+        # Rotate the faces by 270*
+        C.rotation = rotation
+        # And place as a float face over the tree
+        faces.add_face_to_node(C, node, 0, position="float")


### PR DESCRIPTION
There is the skeleton for the balance plot - this is just used for plotting values on the internal nodes. 

There are few things that I would like some input for 

1. Testing - the only way that I know how to test this code is using IPython notebooks.  This is because the actual ETE visualizations aren't tested.  But IPython notebooks aren't ideal to review / modify, due to the underlying json.  Another option is to use [ipymd](https://media.readthedocs.org/pdf/ipymd/latest/ipymd.pdf) to render as markdown.  Or we can use Sphinx to display plots.  I'm not sure what the best way forward on this is
2. The balances parameter in `balanceplot` right now only accepts a `np.array` as input, and assumes level ordering.  I think this is good enough for the first pass.  Eventually I'd like to pass in a `pd.Series` to make this easier to use.  The problem with this is the internal nodes within the tree aren't labeled most of the time.
3. Display layouts.  All of the ETE display parameters are enforced within a `layout` function.  I think the default layouts that I have atm are good enough for the first pass, but I'd like to hear some ideas on how to improve the usability of this.