### PR TITLE
PERF: more direct use of numpy

### DIFF
--- a/gneiss/balances.py
+++ b/gneiss/balances.py
@@ -10,25 +10,37 @@ from gneiss.layouts import default_layout
 def _balance_basis(tree_node):
     """ Helper method for calculating balance basis
     """
-    counts, n_tips = _count_matrix(tree_node)
-    counts = OrderedDict([(x, counts[x])
-                          for x in counts.keys() if not x.is_tip()])
-    nds = counts.keys()
-    r = np.array([counts[n]['r'] for n in nds])
-    s = np.array([counts[n]['l'] for n in nds])
-    k = np.array([counts[n]['k'] for n in nds])
-    t = np.array([counts[n]['t'] for n in nds])
+    # TODO: use recarray
+    # col 0 -> right counts
+    # col 1 -> left counts
+    # col 2 -> k
+    # col 3 -> t
+    r_idx = 0
+    l_idx = 1
+    k_idx = 2
+    t_idx = 3
+
+    counts, n_tips, n_nodes = _count_matrix(tree_node)
+    r = counts[:, r_idx]
+    s = counts[:, l_idx]
+    k = counts[:, k_idx]
+    t = counts[:, t_idx]
 
     a = np.sqrt(s / (r*(r+s)))
     b = -1*np.sqrt(r / (s*(r+s)))
 
     basis = np.zeros((n_tips-1, n_tips))
-    for i in range(len(nds)):
-        basis[i, :] = np.array([0]*k[i] + [a[i]]*r[i] + [b[i]]*s[i] + [0]*t[i])
-    # Make sure that the basis is in level order
-    basis = basis[:, ::-1]
-    nds = list(nds)
-    return basis, nds
+    for i in np.arange(n_nodes - n_tips, dtype=int):
+        v = basis[i]
+
+        k_i = n_tips - k[i]
+        r_i = k_i - r[i]
+        s_i = r_i - s[i]
+
+        v[r_i:k_i] = a[i]
+        v[s_i:r_i] = b[i]
+
+    return basis, [n for n in tree_node.levelorder() if not n.is_tip()]
 
 
 def balance_basis(tree_node):
@@ -90,51 +102,63 @@ def balance_basis(tree_node):
 
 
 def _count_matrix(treenode):
-    n_tips = 0
-    nodes = list(treenode.levelorder(include_self=True))
-    # fill in the Ordered dictionary. Note that the
-    # elements of this Ordered dictionary are
-    # dictionaries.
-    counts = OrderedDict()
-    columns = ['k', 'r', 'l', 't', 'tips']
-    for n in nodes:
-        if n not in counts:
-            counts[n] = {}
-        for c in columns:
-            counts[n][c] = 0
-
-    # fill in r and l.  This is done in reverse level order.
-    for n in nodes[::-1]:
+    node_count = 0
+    for n in treenode.postorder(include_self=True):
+        node_count += 1
         if n.is_tip():
-            counts[n]['tips'] = 1
-            n_tips += 1
-        elif len(n.children) == 2:
-            lchild = n.children[0]
-            rchild = n.children[1]
-            counts[n]['r'] = counts[rchild]['tips']
-            counts[n]['l'] = counts[lchild]['tips']
-            counts[n]['tips'] = counts[n]['r'] + counts[n]['l']
+            n._tip_count = 1
         else:
-            raise ValueError("Not a strictly bifurcating tree!")
+            try:
+                left, right = n.children
+            except:
+                raise ValueError("Not a strictly bifurcating tree!")
+            n._tip_count = left._tip_count + right._tip_count
 
-    # fill in k and t
-    for n in nodes:
-        if n.parent is None:
-            counts[n]['k'] = 0
-            counts[n]['t'] = 0
+    # TODO: use recarray
+    # col 0 -> right counts
+    # col 1 -> left counts
+    # col 2 -> k
+    # col 3 -> t
+    r_idx = 0
+    l_idx = 1
+    k_idx = 2
+    t_idx = 3
+    counts = np.zeros((node_count, 4), dtype=int)
+
+    for i, n in enumerate(treenode.levelorder(include_self=True)):
+        if n.is_tip():
             continue
-        elif n.is_tip():
-            continue
-        # left or right child
-        # left = 0, right = 1
-        child_idx = 'l' if n.parent.children[0] != n else 'r'
-        if child_idx == 'l':
-            counts[n]['t'] = counts[n.parent]['t'] + counts[n.parent]['l']
-            counts[n]['k'] = counts[n.parent]['k']
+
+        n._lo_idx = i
+        node_counts = counts[i]
+
+        node_counts[r_idx] = 1 if n.is_tip() else n.children[1]._tip_count
+        node_counts[l_idx] = 1 if n.is_tip() else n.children[0]._tip_count
+
+        if n.is_root():
+            k = 0
+            t = 0
         else:
-            counts[n]['k'] = counts[n.parent]['k'] + counts[n.parent]['r']
-            counts[n]['t'] = counts[n.parent]['t']
-    return counts, n_tips
+            parent_counts = counts[n.parent._lo_idx]
+            if n is n.parent.children[0]:
+                #t = parent_counts[t_idx] + parent_counts[l_idx]
+                #k = parent_counts[k_idx]
+
+                k = parent_counts[k_idx] + parent_counts[r_idx]
+                t = parent_counts[t_idx]
+            else:
+                #k = parent_counts[k_idx] + parent_counts[r_idx]
+                #t = parent_counts[t_idx]
+
+                k = parent_counts[k_idx]
+                t = parent_counts[t_idx] + parent_counts[l_idx]
+
+        node_counts[k_idx] = k
+        node_counts[t_idx] = t
+
+        counts[i] = node_counts
+
+    return counts, treenode._tip_count, node_count
 
 
 def _attach_balances(balances, tree):

--- a/gneiss/tests/test_balances.py
+++ b/gneiss/tests/test_balances.py
@@ -48,8 +48,8 @@ class TestPlot(unittest.TestCase):
         tree = TreeNode.read([u"((a,b)c,d)r;"])
         balances = np.array([10, -10])
         tr, ts = balanceplot(balances, tree)
-        self.assertEquals(ts.mode, 'c')
-        self.assertEquals(ts.layout_fn[0], default_layout)
+        self.assertEqual(ts.mode, 'c')
+        self.assertEqual(ts.layout_fn[0], default_layout)
 
 
 class TestBalances(unittest.TestCase):
@@ -57,30 +57,31 @@ class TestBalances(unittest.TestCase):
     def test_count_matrix_base_case(self):
         tree = u"(a,b);"
         t = TreeNode.read([tree])
-        res, _ = _count_matrix(t)
-        exp = {'k': 0, 'l': 1, 'r': 1, 't': 0, 'tips': 2}
-        self.assertEqual(res[t], exp)
+        res, _, _ = _count_matrix(t)
 
-        exp = {'k': 0, 'l': 0, 'r': 0, 't': 0, 'tips': 1}
-        self.assertEqual(res[t[0]], exp)
+        exp = np.array([1, 1, 0, 0])
+        npt.assert_equal(res[0], exp)
 
-        exp = {'k': 0, 'l': 0, 'r': 0, 't': 0, 'tips': 1}
-        self.assertEqual(res[t[1]], exp)
+        exp = np.array([0, 0, 0, 0])
+        npt.assert_equal(res[1], exp)
+
+        exp = np.array([0, 0, 0, 0])
+        npt.assert_equal(res[2], exp)
 
     def test_count_matrix_unbalanced(self):
         tree = u"((a,b)c, d);"
         t = TreeNode.read([tree])
-        res, _ = _count_matrix(t)
+        res, _, _ = _count_matrix(t)
 
-        exp = {'k': 0, 'l': 2, 'r': 1, 't': 0, 'tips': 3}
-        self.assertEqual(res[t], exp)
-        exp = {'k': 1, 'l': 1, 'r': 1, 't': 0, 'tips': 2}
-        self.assertEqual(res[t[0]], exp)
+        exp = np.array([1, 2, 0, 0])
+        npt.assert_equal(res[0], exp)
+        exp = np.array([1, 1, 1, 0])
+        npt.assert_equal(res[1], exp)
 
-        exp = {'k': 0, 'l': 0, 'r': 0, 't': 0, 'tips': 1}
-        self.assertEqual(res[t[1]], exp)
-        self.assertEqual(res[t[0][0]], exp)
-        self.assertEqual(res[t[0][1]], exp)
+        exp = np.array([0, 0, 0, 0])
+        npt.assert_equal(res[2], exp)
+        npt.assert_equal(res[3], exp)
+        npt.assert_equal(res[4], exp)
 
     def test_count_matrix_singleton_error(self):
         with self.assertRaises(ValueError):
@@ -150,6 +151,13 @@ class TestBalances(unittest.TestCase):
             get_data_path('large_tree_basis.txt',
                           subfolder='data'))
         res_basis, res_keys = balance_basis(t)
+
+        exp_basis = exp_basis[:, ::-1]
+        print(exp_basis.shape)
+        for i in range(len(res_basis)):
+            print(i)
+            npt.assert_allclose(exp_basis[i], res_basis[i])
+
         npt.assert_allclose(exp_basis[:, ::-1], res_basis)
 
 


### PR DESCRIPTION
@mortonjt, was thinking something along these lines. Note, the large test is failing and I'm not sure why. One issue I encountered was that I had to switch up the calculation of `k` and `t` (see [here](https://github.com/biocore/gneiss/compare/master...wasade:perf_tweaks?expand=1#diff-50b1a1692a03c26a330c3689f064d40aR143) as the original formulation was leading to more test failures. However, I fully recognize that that is probably why the large test is failing... anyway, any insight here would be great. I haven't benched this but I strongly suspect the `_balance_basis` call will be much more efficient, and there is still additional fat to trim if desired. 

Also, because of the failure, I think the print statements in the test code are fine as it may highlight a little more about what might be going on. 
