### PR TITLE
BUGFIX: Allow for no bgcolors and fix get_farthest_leaf issue

### DIFF
--- a/gneiss/plot/_blobtree.py
+++ b/gneiss/plot/_blobtree.py
@@ -156,6 +156,7 @@ def diamondtree(tree, **kwargs):
             nst = NodeStyle()
             nst["bgcolor"] = c
             node.set_style(nst)
+
         if node.name in collapsed_nodes:
             # scaling factor for approximating subtree depth
             w = node.get_farthest_node()[1]*depth_scaling
@@ -213,6 +214,8 @@ def _get_node_color(x, node, default_color):
             return x.loc[node.name], True
         elif isinstance(x, dict):
             return x[node.name], True
+        elif x is None:
+            return "", False
         else:
             raise TypeError("color type %s not supported." % type(x).__name__)
     except KeyError:

--- a/gneiss/plot/_blobtree.py
+++ b/gneiss/plot/_blobtree.py
@@ -159,7 +159,8 @@ def diamondtree(tree, **kwargs):
 
         if node.name in collapsed_nodes:
             # scaling factor for approximating subtree depth
-            w = node.get_farthest_node()[1]*depth_scaling
+            depth = node.get_farthest_leaf(topology_only=True)
+            w = depth[1]*depth_scaling
             # scaling factor for approximating for subtree width
             h = len(node)*breadth_scaling
             c, _ = _get_node_color(cladecolors, node, "#0000FF")

--- a/gneiss/plot/tests/test_blobtree.py
+++ b/gneiss/plot/tests/test_blobtree.py
@@ -35,5 +35,13 @@ class BlobTreeTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.fname))
         self.assertTrue(os.path.getsize(self.fname) > 0)
 
+    def test_no_colors(self):
+        st = TreeNode.read(get_data_path(self.newick))
+        tr, ts = diamondtree(st, breadth_scaling=6, depth_scaling=30)
+
+        tr.render(file_name=self.fname, tree_style=ts)
+        self.assertTrue(os.path.exists(self.fname))
+        self.assertTrue(os.path.getsize(self.fname) > 0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A couple of bug fixes here

1. The bgcolors option now doesn't need to be specified.  Before it was strictly required

2. `get_farthest_leaf` is now being used.  Before `get_farthest_node` was being used, which searched the entire tree, instead of just searching the descendants.