### PR TITLE
Leave one out cross validation

### DIFF
--- a/gneiss/regression/_ols.py
+++ b/gneiss/regression/_ols.py
@@ -21,7 +21,6 @@ import inspect
 
 def _fit_ols(y, x, **kwargs):
     """ Perform the basic ols regression."""
-    #one-time creation of exogenous data matrix allows for faster run-time
     exog_data = x
     submodels = []
     for b in y.columns:
@@ -31,6 +30,7 @@ def _fit_ols(y, x, **kwargs):
         mdf = smf.OLS(endog=endog_data, exog=exog_data, **kwargs)
         submodels.append(mdf)
     return submodels
+
 
 # TODO: Register as qiime 2 method
 def ols(formula, table, metadata, tree, **kwargs):
@@ -172,6 +172,7 @@ def ols(formula, table, metadata, tree, **kwargs):
                                                               tree)
     ilr_table, basis = _to_balances(table, tree)
     ilr_table, metadata = ilr_table.align(metadata, join='inner', axis=0)
+    # one-time creation of exogenous data matrix allows for faster run-time
     x = dmatrix(formula, metadata, return_type='dataframe')
     submodels = _fit_ols(ilr_table, x)
     return OLSModel(submodels, basis=basis,
@@ -359,7 +360,7 @@ class OLSModel(RegressionModel):
             params[key] = kwargs.get(key, params[key])
             kwargs.pop(key, None)
 
-        nobs = self.balances.shape[0] # number of observations (i.e. samples)
+        nobs = self.balances.shape[0]  # number of observations (i.e. samples)
         cv_iter = LeaveOneOut(nobs)
         endog = self.balances
         exog_names = self.results[0].model.exog_names
@@ -422,7 +423,7 @@ class OLSModel(RegressionModel):
 
             kwargs.pop(key, None)
 
-        nobs = self.balances.shape[0] # number of observations (i.e. samples)
+        nobs = self.balances.shape[0]  # number of observations (i.e. samples)
 
         endog = self.balances
         exog_names = self.results[0].model.exog_names
@@ -442,10 +443,9 @@ class OLSModel(RegressionModel):
                 res_i = [r.fit(**kwargs) for r in res_i]
             # See `statsmodels.regression.linear_model.RegressionResults`
             # for more explanation on `ess` and `ssr`.
-            # sum of squares regression. Also referred to as
-            # explained sum of squares.
+            # sum of squares regression.
             ssr = sum([r.ess for r in res_i])
-            # sum of squares error.  Also referred to as sum of squares residuals
+            # sum of squares error.
             sse = sum([r.ssr for r in res_i])
             # calculate the overall coefficient of determination (i.e. R2)
             sst = sse + ssr
@@ -453,7 +453,7 @@ class OLSModel(RegressionModel):
             # degrees of freedom for residuals
             dfe = res_i[0].df_resid
             results.loc[feature_id, 'mse'] = sse / dfe
-            i+=1
+            i += 1
         return results
 
     def percent_explained(self):
@@ -462,4 +462,3 @@ class OLSModel(RegressionModel):
         # instead of population variance (df=0).
         axis_vars = np.var(self.balances, ddof=1, axis=0)
         return axis_vars / axis_vars.sum()
-

--- a/gneiss/regression/_ols.py
+++ b/gneiss/regression/_ols.py
@@ -352,8 +352,8 @@ class OLSModel(RegressionModel):
 
         for i, (inidx, outidx) in enumerate(cv_iter):
             sample_id = self.balances.index[i]
-            res_i = _fit_ols(y=endog.loc[inidx], x=exog.loc[inidx], **kwargs)
-            res_i = [r.fit(**kwargs) for r in res_i]
+            model_i = _fit_ols(y=endog.loc[inidx], x=exog.loc[inidx], **kwargs)
+            res_i = [r.fit(**kwargs) for r in model_i]
 
             # mean sum of squares error
             sse = sum([r.ssr for r in res_i])

--- a/gneiss/regression/_ols.py
+++ b/gneiss/regression/_ols.py
@@ -16,7 +16,6 @@ import statsmodels.formula.api as smf
 from statsmodels.iolib.summary2 import Summary
 from statsmodels.sandbox.tools.cross_val import LeaveOneOut
 from patsy import dmatrix
-import inspect
 
 
 def _fit_ols(y, x, **kwargs):
@@ -422,8 +421,6 @@ class OLSModel(RegressionModel):
             params[key] = kwargs.get(key, params[key])
 
             kwargs.pop(key, None)
-
-        nobs = self.balances.shape[0]  # number of observations (i.e. samples)
 
         endog = self.balances
         exog_names = self.results[0].model.exog_names

--- a/gneiss/regression/_ols.py
+++ b/gneiss/regression/_ols.py
@@ -20,7 +20,6 @@ from patsy import dmatrix
 
 def _fit_ols(y, x, **kwargs):
     """ Perform the basic ols regression."""
-    exog_data = x
     # mixed effects code is obtained here:
     # http://stackoverflow.com/a/22439820/1167475
     submodels = [smf.OLS(endog=y[b], exog=x, **kwargs) for b in y.columns]

--- a/gneiss/regression/_ols.py
+++ b/gneiss/regression/_ols.py
@@ -7,14 +7,30 @@
 # ----------------------------------------------------------------------------
 from decimal import Decimal
 from collections import OrderedDict
-
+import numpy as np
 import pandas as pd
 from gneiss.regression._model import RegressionModel
 from ._regression import (_intersect_of_table_metadata_tree,
                           _to_balances)
 import statsmodels.formula.api as smf
 from statsmodels.iolib.summary2 import Summary
+from statsmodels.sandbox.tools.cross_val import LeaveOneOut
+from patsy import dmatrix
+import inspect
 
+
+def _fit_ols(y, x, **kwargs):
+    """ Perform the basic ols regression."""
+    #one-time creation of exogenous data matrix allows for faster run-time
+    exog_data = x
+    submodels = []
+    for b in y.columns:
+        endog_data = y[b]
+        # mixed effects code is obtained here:
+        # http://stackoverflow.com/a/22439820/1167475
+        mdf = smf.OLS(endog=endog_data, exog=exog_data, **kwargs)
+        submodels.append(mdf)
+    return submodels
 
 # TODO: Register as qiime 2 method
 def ols(formula, table, metadata, tree, **kwargs):
@@ -155,18 +171,9 @@ def ols(formula, table, metadata, tree, **kwargs):
                                                               metadata,
                                                               tree)
     ilr_table, basis = _to_balances(table, tree)
-    data = pd.merge(ilr_table, metadata, left_index=True, right_index=True)
-
-    submodels = []
-
-    for b in ilr_table.columns:
-        # mixed effects code is obtained here:
-        # http://stackoverflow.com/a/22439820/1167475
-        stats_formula = '%s ~ %s' % (b, formula)
-
-        mdf = smf.ols(stats_formula, data=data, **kwargs)
-        submodels.append(mdf)
-
+    ilr_table, metadata = ilr_table.align(metadata, join='inner', axis=0)
+    x = dmatrix(formula, metadata, return_type='dataframe')
+    submodels = _fit_ols(ilr_table, x)
     return OLSModel(submodels, basis=basis,
                     balances=ilr_table,
                     tree=tree)
@@ -203,11 +210,24 @@ class OLSModel(RegressionModel):
         """
         super().__init__(*args, **kwargs)
 
-    def fit(self, **kwargs):
-        """ Fit the model """
+    def fit(self, regularized=False, **kwargs):
+        """ Fit the model.
+
+        Parameters
+        ----------
+        regularized : bool
+            Specifies if a regularization procedure should be used
+            when performing the fit. (default = False)
+        **kwargs : dict
+           Keyword arguments used to tune the parameter estimation.
+
+        """
         for s in self.submodels:
             # assumes that the underlying submodels have implemented `fit`.
-            m = s.fit(**kwargs)
+            if regularized:
+                m = s.fit(**kwargs)
+            else:
+                m = s.fit_regularized(**kwargs)
             self.results.append(m)
 
     def summary(self, ndim=10):
@@ -298,3 +318,148 @@ class OLSModel(RegressionModel):
 
         sst = sse + ssr
         return 1 - sse / sst
+
+    @property
+    def mse(self):
+        sse = sum([r.ssr for r in self.results])
+        dfe = self.results[0].df_resid
+        return sse / dfe
+
+    def loo(self, regularized=False, **kwargs):
+        """ Leave one out cross-validation.
+
+        Calculates summary statistics for each iteraction of
+        leave one out cross-validation, specially `mse` on entire model
+        and `pred_err` to measure prediction error.
+
+        Parameters
+        ----------
+        regularized : bool
+            Specifies if a regularization procedure should be used
+            when performing the fit.
+        **kwargs : dict
+           Keyword arguments used to tune the parameter estimation.
+
+        Returns
+        -------
+        pd.DataFrame
+           mse : np.array, float
+               Mean sum of squares error for each iteration of
+               the cross validation.
+           pred_err : np.array, float
+               Prediction mean sum of squares error for each iteration of
+               the cross validation.
+
+        See Also
+        --------
+        fit
+        """
+        params = {'fit_regularized': False}
+        for key in params:
+            params[key] = kwargs.get(key, params[key])
+            kwargs.pop(key, None)
+
+        nobs = self.balances.shape[0] # number of observations (i.e. samples)
+        cv_iter = LeaveOneOut(nobs)
+        endog = self.balances
+        exog_names = self.results[0].model.exog_names
+        exog = pd.DataFrame(self.results[0].model.exog,
+                            index=self.balances.index,
+                            columns=exog_names)
+        results = pd.DataFrame(index=self.balances.index,
+                               columns=['mse', 'pred_err'])
+        i = 0
+        for inidx, outidx in cv_iter:
+            sample_id = self.balances.index[i]
+            res_i = _fit_ols(y=endog.loc[inidx], x=exog.loc[inidx], **kwargs)
+            if params['fit_regularized']:
+                res_i = [r.fit_regularized(**kwargs) for r in res_i]
+            else:
+                res_i = [r.fit(**kwargs) for r in res_i]
+
+            # mean sum of squares error
+            sse = sum([r.ssr for r in res_i])
+            # degrees of freedom for residuals
+            dfe = res_i[0].df_resid
+            results.loc[sample_id, 'mse'] = sse / dfe
+
+            # prediction error on loo point
+            predicted = np.hstack([r.predict(exog.loc[outidx]) for r in res_i])
+
+            pred_sse = np.sum((predicted - self.balances.loc[outidx])**2)
+            results.loc[sample_id, 'pred_err'] = pred_sse.sum()
+            i += 1
+        return results
+
+    def lovo(self, **kwargs):
+        """ Leave one variable out cross-validation.
+
+        Calculates summary statistics for each iteraction of leave one variable
+        out cross-validation, specially `r2` and `mse` on entire model.
+        This technique is particularly useful for feature selection.
+
+        Parameters
+        ----------
+        regularized : bool
+            Specifies if a regularization procedure should be used
+            when performing the fit.
+        **kwargs : dict
+           Keyword arguments used to tune the parameter estimation.
+
+        Returns
+        -------
+        pd.DataFrame
+           Rsquared : np.array, flot
+               Coefficient of determination for each variable left out.
+           mse : np.array, float
+               Mean sum of squares error for each iteration of
+               the cross validation.
+        """
+
+        params = {'regularized': False}
+        for key in params:
+            params[key] = kwargs.get(key, params[key])
+
+            kwargs.pop(key, None)
+
+        nobs = self.balances.shape[0] # number of observations (i.e. samples)
+
+        endog = self.balances
+        exog_names = self.results[0].model.exog_names
+        exog = pd.DataFrame(self.results[0].model.exog,
+                            index=self.balances.index,
+                            columns=exog_names)
+        cv_iter = LeaveOneOut(len(exog_names))
+        results = pd.DataFrame(index=exog_names,
+                               columns=['mse', 'Rsquared'])
+        i = 0
+        for inidx, outidx in cv_iter:
+            feature_id = exog_names[i]
+            res_i = _fit_ols(endog, exog.loc[:, inidx], **kwargs)
+            if params['regularized']:
+                res_i = [r.fit_regularized(**kwargs) for r in res_i]
+            else:
+                res_i = [r.fit(**kwargs) for r in res_i]
+            # See `statsmodels.regression.linear_model.RegressionResults`
+            # for more explanation on `ess` and `ssr`.
+            # sum of squares regression. Also referred to as
+            # explained sum of squares.
+            ssr = sum([r.ess for r in res_i])
+            # sum of squares error.  Also referred to as sum of squares residuals
+            sse = sum([r.ssr for r in res_i])
+            # calculate the overall coefficient of determination (i.e. R2)
+            sst = sse + ssr
+            results.loc[feature_id, 'Rsquared'] = 1 - sse / sst
+            # degrees of freedom for residuals
+            dfe = res_i[0].df_resid
+            results.loc[feature_id, 'mse'] = sse / dfe
+            i+=1
+        return results
+
+    def percent_explained(self):
+        """ Proportion explained by each principal balance."""
+        # Using sum of squares error calculation (df=1)
+        # instead of population variance (df=0).
+        axis_vars = np.var(self.balances, ddof=1, axis=0)
+        return axis_vars / axis_vars.sum()
+

--- a/gneiss/regression/_ols.py
+++ b/gneiss/regression/_ols.py
@@ -22,8 +22,7 @@ def _fit_ols(y, x, **kwargs):
     """ Perform the basic ols regression."""
     # mixed effects code is obtained here:
     # http://stackoverflow.com/a/22439820/1167475
-    submodels = [smf.OLS(endog=y[b], exog=x, **kwargs) for b in y.columns]
-    return submodels
+    return [smf.OLS(endog=y[b], exog=x, **kwargs) for b in y.columns]
 
 
 # TODO: Register as qiime 2 method

--- a/gneiss/regression/tests/test_ols.py
+++ b/gneiss/regression/tests/test_ols.py
@@ -40,9 +40,9 @@ class TestOLS(unittest.TestCase):
         x2 = np.logspace(0, 0.01, n)
         x3 = np.exp(np.linspace(0, 0.01, n))
         x4 = x1 ** 2
-        self.x = pd.DataFrame({'x1': x1, 'x2': x2, 'x3': x3, 'x4':x4})
-        y = (a[0] + a[1]*x1 + a[2]*x2 + a[3]*x3 + a[4]*x4 + \
-             (np.random.normal(size=n)))
+        self.x = pd.DataFrame({'x1': x1, 'x2': x2, 'x3': x3, 'x4': x4})
+        y = (a[0] + a[1]*x1 + a[2]*x2 + a[3]*x3 + a[4]*x4 +
+             np.random.normal(size=n))
         sy = np.vstack((y, y/10)).T
         self.y = pd.DataFrame(ilr_inv(sy), columns=['a', 'b', 'c'])
         self.t2 = TreeNode.read([r"((a,b)n,c);"])
@@ -255,7 +255,6 @@ class TestOLS(unittest.TestCase):
         res_coefs = res.coefficients()
         pdt.assert_index_equal(exp_coefs.index, res_coefs.index)
         pdt.assert_index_equal(exp_coefs.columns, res_coefs.columns)
-
 
     def test_loo(self):
         res = ols(formula="x1 + x2 + x3 + x4",

--- a/gneiss/regression/tests/test_ols.py
+++ b/gneiss/regression/tests/test_ols.py
@@ -291,7 +291,7 @@ class TestOLS(unittest.TestCase):
         res = ols(formula="x1 + x2 + x3 + x4",
                   table=self.y, metadata=self.x, tree=self.t2)
         res.fit()
-        self.assertEquals(res.mse, 0.79228890379010453)
+        self.assertAlmostEqual(res.mse, 0.79228890379010453, )
 
 if __name__ == "__main__":
     unittest.main()

--- a/gneiss/regression/tests/test_ols.py
+++ b/gneiss/regression/tests/test_ols.py
@@ -291,7 +291,7 @@ class TestOLS(unittest.TestCase):
         res = ols(formula="x1 + x2 + x3 + x4",
                   table=self.y, metadata=self.x, tree=self.t2)
         res.fit()
-        self.assertAlmostEqual(res.mse, 0.79228890379010453, )
+        self.assertAlmostEqual(res.mse, 0.79228890379010453, places=4)
 
 if __name__ == "__main__":
     unittest.main()

--- a/gneiss/regression/tests/test_ols.py
+++ b/gneiss/regression/tests/test_ols.py
@@ -278,7 +278,7 @@ class TestOLS(unittest.TestCase):
                                columns=['mse', 'pred_err'],
                                index=self.y.index)
         res_loo = res.loo().astype(np.float)
-        pdt.assert_frame_equal(exp_loo, res_loo)
+        pdt.assert_frame_equal(exp_loo, res_loo, check_less_precise=True)
 
         # Make sure that the regularization works
         exp_loo = pd.DataFrame([[0.967322, 0.167080],
@@ -316,7 +316,7 @@ class TestOLS(unittest.TestCase):
                                 columns=['mse', 'Rsquared'],
                                 index=['Intercept', 'x1', 'x2', 'x3', 'x4'])
         res_lovo = res.lovo().astype(np.float)
-        pdt.assert_frame_equal(exp_lovo, res_lovo)
+        pdt.assert_frame_equal(exp_lovo, res_lovo, check_less_precise=True)
 
         # Make sure that the regularization works
         exp_lovo = pd.DataFrame([[0.799364, 0.978214],

--- a/gneiss/regression/tests/test_ols.py
+++ b/gneiss/regression/tests/test_ols.py
@@ -240,22 +240,6 @@ class TestOLS(unittest.TestCase):
             exp = fh.read()
             self.assertEqual(res, exp)
 
-    def test_fit_regularized(self):
-        res = ols(formula="x1 + x2 + x3 + x4",
-                  table=self.y, metadata=self.x, tree=self.t2)
-        res.fit(regularized=True)
-        exp_coefs = pd.DataFrame({
-            'y0': [-2.074816e+09, -2.039271e+08, -1.843143e+08,
-                   2.261170e+09, -7.925699e+06],
-            'y1': [-2.074816e+10, -2.039271e+09, -1.843143e+09,
-                   2.261170e+10, -7.925699e+07]
-            }, index=['Intercept', 'x1', 'x2', 'x3', 'x4']).T
-        # The L1 regularization either has numerical issues
-        # or is random ...
-        res_coefs = res.coefficients()
-        pdt.assert_index_equal(exp_coefs.index, res_coefs.index)
-        pdt.assert_index_equal(exp_coefs.columns, res_coefs.columns)
-
     def test_loo(self):
         res = ols(formula="x1 + x2 + x3 + x4",
                   table=self.y, metadata=self.x, tree=self.t2)
@@ -280,30 +264,6 @@ class TestOLS(unittest.TestCase):
         res_loo = res.loo().astype(np.float)
         pdt.assert_frame_equal(exp_loo, res_loo, check_less_precise=True)
 
-        # Make sure that the regularization works
-        exp_loo = pd.DataFrame([[0.967322, 0.167080],
-                                [0.849595, 1.565647],
-                                [0.975039, 0.021956],
-                                [0.752424, 2.312112],
-                                [0.820359, 1.605247],
-                                [0.643426, 3.464196],
-                                [0.953059, 0.252861],
-                                [0.930367, 0.495480],
-                                [0.945151, 0.336588],
-                                [0.976778, 0.003095],
-                                [0.971040, 0.061874],
-                                [0.830764, 1.505806],
-                                [0.963017, 0.151680],
-                                [0.953350, 0.291705],
-                                [0.970680, 0.107289]],
-                               columns=['mse', 'pred_err'],
-                               index=self.y.index)
-        res = ols(formula="x1 + x2 + x3 + x4",
-                  table=self.y, metadata=self.x, tree=self.t2)
-        res.fit(regularized=True)
-        res_loo = res.loo(fit_regularized=True).astype(np.float)
-        pdt.assert_frame_equal(exp_loo, res_loo, check_less_precise=True)
-
     def test_lovo(self):
         res = ols(formula="x1 + x2 + x3 + x4",
                   table=self.y, metadata=self.x, tree=self.t2)
@@ -316,20 +276,6 @@ class TestOLS(unittest.TestCase):
                                 columns=['mse', 'Rsquared'],
                                 index=['Intercept', 'x1', 'x2', 'x3', 'x4'])
         res_lovo = res.lovo().astype(np.float)
-        pdt.assert_frame_equal(exp_lovo, res_lovo, check_less_precise=True)
-
-        # Make sure that the regularization works
-        exp_lovo = pd.DataFrame([[0.799364, 0.978214],
-                                 [0.799363, 0.097355],
-                                 [0.799368, 0.0973498],
-                                 [0.799364, 0.097354],
-                                 [0.799361, 0.0973575]],
-                                columns=['mse', 'Rsquared'],
-                                index=['Intercept', 'x1', 'x2', 'x3', 'x4'])
-        res = ols(formula="x1 + x2 + x3 + x4",
-                  table=self.y, metadata=self.x, tree=self.t2)
-        res.fit(regularized=True)
-        res_lovo = res.lovo(fit_regularized=True).astype(np.float)
         pdt.assert_frame_equal(exp_lovo, res_lovo, check_less_precise=True)
 
     def test_percent_explained(self):
@@ -345,8 +291,7 @@ class TestOLS(unittest.TestCase):
         res = ols(formula="x1 + x2 + x3 + x4",
                   table=self.y, metadata=self.x, tree=self.t2)
         res.fit()
-        self.assertEquals(res.mse, 0.87936961790361856)
-
+        self.assertEquals(res.mse, 0.79228890379010453)
 
 if __name__ == "__main__":
     unittest.main()

--- a/gneiss/regression/tests/test_ols.py
+++ b/gneiss/regression/tests/test_ols.py
@@ -303,17 +303,50 @@ class TestOLS(unittest.TestCase):
                   table=self.y, metadata=self.x, tree=self.t2)
         res.fit(regularized=True)
         res_loo = res.loo(fit_regularized=True).astype(np.float)
-
         pdt.assert_frame_equal(exp_loo, res_loo, check_less_precise=True)
 
     def test_lovo(self):
-        self.assertTrue(False)
+        res = ols(formula="x1 + x2 + x3 + x4",
+                  table=self.y, metadata=self.x, tree=self.t2)
+        res.fit()
+        exp_lovo = pd.DataFrame([[0.799364, 0.978214],
+                                 [0.799363, 0.097355],
+                                 [0.799368, 0.0973498],
+                                 [0.799364, 0.097354],
+                                 [0.799361, 0.0973575]],
+                                columns=['mse', 'Rsquared'],
+                                index=['Intercept', 'x1', 'x2', 'x3', 'x4'])
+        res_lovo = res.lovo().astype(np.float)
+        pdt.assert_frame_equal(exp_lovo, res_lovo)
+
+        # Make sure that the regularization works
+        exp_lovo = pd.DataFrame([[0.799364, 0.978214],
+                                 [0.799363, 0.097355],
+                                 [0.799368, 0.0973498],
+                                 [0.799364, 0.097354],
+                                 [0.799361, 0.0973575]],
+                                columns=['mse', 'Rsquared'],
+                                index=['Intercept', 'x1', 'x2', 'x3', 'x4'])
+        res = ols(formula="x1 + x2 + x3 + x4",
+                  table=self.y, metadata=self.x, tree=self.t2)
+        res.fit(regularized=True)
+        res_lovo = res.lovo(fit_regularized=True).astype(np.float)
+        pdt.assert_frame_equal(exp_lovo, res_lovo, check_less_precise=True)
 
     def test_percent_explained(self):
-        self.assertTrue(False)
+        res = ols(formula="x1 + x2 + x3 + x4",
+                  table=self.y, metadata=self.x, tree=self.t2)
+        res.fit()
+        res_perc = res.percent_explained()
+        exp_perc = pd.Series({'y0': 0.009901,
+                              'y1': 0.990099})
+        pdt.assert_series_equal(res_perc, exp_perc)
 
     def test_mse(self):
-        self.assertTrue(False)
+        res = ols(formula="x1 + x2 + x3 + x4",
+                  table=self.y, metadata=self.x, tree=self.t2)
+        res.fit()
+        self.assertEquals(res.mse, 0.87936961790361856)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are a few things that are added to this PR namely

- percent_explained : calculates the percentage of the total variance explained for each balance axis (think about the analogue for principal components).

- leave one out cross validation : calculates model error on training dataset and prediction error on testing dataset

- leave one variable out cross validation : calculates R^2 and model error when each variable is left out of the model.  This gives us an idea about the variable importance for each variable.  But more work concerning effect size of each variable will need to be done in the future

In addition, the OLS procedure was slightly optimized to reduce the amount of formula -> matrix conversions that needed to be computed.  Will need to propagate this to the remaining methods.  Thanks @Josh-Lefler for discovering this!

Remember, this is the last major PR that needs to be merged in.  Reviews will be greatly appreciated.  Thanks!