### PR TITLE
MAINT: update travis for new QIIME 2 automatic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
 install:
-  - conda create --yes -n test_env python=$PYVERSION --file ci/conda_requirements.txt -c biocore
+  - conda create --yes -n test_env python=$PYVERSION --file https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-conda-linux-64.txt
+  - conda install --yes -n test_env --file ci/conda_requirements.txt -c biocore
   - conda install --yes -n test_env cython
   - source activate test_env
   - pip install -r ci/pip_requirements.txt
-  - pip install -r ci/qiime_requirements.txt
   - pip install -e .
 script:
   - WITH_COVERAGE=TRUE make all

--- a/ci/qiime_requirements.txt
+++ b/ci/qiime_requirements.txt
@@ -1,6 +1,0 @@
-git+https://github.com/qiime2/qiime2.git
-git+https://github.com/qiime2/q2-types.git
-git+https://github.com/qiime2/q2templates.git
-git+https://github.com/qiime2/q2-composition.git
-git+https://github.com/qiime2/q2cli.git
-git+https://github.com/qiime2/q2-feature-table.git


### PR DESCRIPTION
This should let travis pass now. It's using the new environment file generated by QIIME 2's automatic CI system, which creates new conda packages for every merged commit.

I'm not completely sure how you want to organize things here, but this can be used as a template if nothing else.