### PR TITLE
BLD: Fix setup.py extra_require -> extras_require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - conda install --yes -n test_env cython
   - source activate test_env
   - pip install -r ci/pip_requirements.txt
-  - pip install -e .
+  - pip install -e '.[q2]'
 script:
   - WITH_COVERAGE=TRUE make all
   - if [ ${MAKE_DOC} ]; then make -C doc clean html; fi

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(name='gneiss',
           'scikit-bio==0.5.1',
           'statsmodels>=0.8.0',
       ],
-      extra_require={
+      extras_require={
           'q2': ['qiime2 >= 2017.2.0', 'biom-format', 'seaborn']
       },
       classifiers=classifiers,


### PR DESCRIPTION
There was a typo in setup.py that prevented users from installing
gneiss' QIIME2 dependencies.  This also adds a line in needed
.travis.yml to install gneiss using the [q2] extras.