### PR TITLE
MAINT: stop using deprecated pandas reindex_axis

### DIFF
--- a/gneiss/tests/test_util.py
+++ b/gneiss/tests/test_util.py
@@ -335,13 +335,13 @@ class TestMatch(unittest.TestCase):
         exp_df = pd.DataFrame(exp_table.to_dataframe())
         res_df = pd.DataFrame(res_table.to_dataframe())
 
-        exp_df = exp_df.reindex_axis(sorted(exp_df.columns), axis=1)
-        res_df = res_df.reindex_axis(sorted(res_df.columns), axis=1)
+        exp_df = exp_df.reindex(sorted(exp_df.columns), axis=1)
+        res_df = res_df.reindex(sorted(res_df.columns), axis=1)
 
         pdt.assert_frame_equal(exp_df, res_df)
 
-        exp_md = exp_md.reindex_axis(sorted(exp_md.index), axis=0)
-        res_md = res_md.reindex_axis(sorted(res_md.index), axis=0)
+        exp_md = exp_md.reindex(sorted(exp_md.index), axis=0)
+        res_md = res_md.reindex(sorted(res_md.index), axis=0)
 
         pdt.assert_frame_equal(res_md, exp_md)
 

--- a/gneiss/util.py
+++ b/gneiss/util.py
@@ -242,7 +242,7 @@ def _dense_match_tips(table, tree):
     _tree.bifurcate()
     _tree.prune()
     sorted_features = [n.name for n in _tree.tips()]
-    _table = _table.reindex_axis(sorted_features, axis=1)
+    _table = _table.reindex(sorted_features, axis=1)
     return _table, _tree
 
 


### PR DESCRIPTION
`pandas 0.25.x` [removed](https://pandas.pydata.org/pandas-docs/version/0.25/whatsnew/v0.25.0.html#removal-of-prior-version-deprecations-changes) the deprecated `.reindex_axis` method. This PR replaces calls to `.reindex_axis` with `.reindex`. As best I can tell, no other changes are necessary.