### PR TITLE
MAINT: update reindex_axis for pandas 0.25.1

### DIFF
--- a/gneiss/plot/tests/test_dendrogram.py
+++ b/gneiss/plot/tests/test_dendrogram.py
@@ -33,13 +33,13 @@ class TestDendrogram(unittest.TestCase):
 
         t._cache_ntips()
 
-        self.assertEquals(t.leafcount, 4)
-        self.assertEquals(t.children[0].leafcount, 2)
-        self.assertEquals(t.children[1].leafcount, 2)
-        self.assertEquals(t.children[0].children[0].leafcount, 1)
-        self.assertEquals(t.children[0].children[1].leafcount, 1)
-        self.assertEquals(t.children[1].children[0].leafcount, 1)
-        self.assertEquals(t.children[1].children[1].leafcount, 1)
+        self.assertEqual(t.leafcount, 4)
+        self.assertEqual(t.children[0].leafcount, 2)
+        self.assertEqual(t.children[1].leafcount, 2)
+        self.assertEqual(t.children[0].children[0].leafcount, 1)
+        self.assertEqual(t.children[0].children[1].leafcount, 1)
+        self.assertEqual(t.children[1].children[0].leafcount, 1)
+        self.assertEqual(t.children[1].children[1].leafcount, 1)
 
 
 class TestUnrootedDendrogram(unittest.TestCase):

--- a/gneiss/tests/test_util.py
+++ b/gneiss/tests/test_util.py
@@ -335,13 +335,13 @@ class TestMatch(unittest.TestCase):
         exp_df = pd.DataFrame(exp_table.to_dataframe())
         res_df = pd.DataFrame(res_table.to_dataframe())
 
-        exp_df = exp_df.reindex_axis(sorted(exp_df.columns), axis=1)
-        res_df = res_df.reindex_axis(sorted(res_df.columns), axis=1)
+        exp_df = exp_df.reindex(sorted(exp_df.columns), axis=1)
+        res_df = res_df.reindex(sorted(res_df.columns), axis=1)
 
         pdt.assert_frame_equal(exp_df, res_df)
 
-        exp_md = exp_md.reindex_axis(sorted(exp_md.index), axis=0)
-        res_md = res_md.reindex_axis(sorted(res_md.index), axis=0)
+        exp_md = exp_md.reindex(sorted(exp_md.index), axis=0)
+        res_md = res_md.reindex(sorted(res_md.index), axis=0)
 
         pdt.assert_frame_equal(res_md, exp_md)
 

--- a/gneiss/util.py
+++ b/gneiss/util.py
@@ -242,7 +242,7 @@ def _dense_match_tips(table, tree):
     _tree.bifurcate()
     _tree.prune()
     sorted_features = [n.name for n in _tree.tips()]
-    _table = _table.reindex_axis(sorted_features, axis=1)
+    _table = _table.reindex(sorted_features, axis=1)
     return _table, _tree
 
 


### PR DESCRIPTION
Hey @mortonjt, we were updating QIIME 2's environment, and we saw gneiss was still using the older pandas API which has since been removed. Fortunately, it's a [very simple fix](https://pandas.pydata.org/pandas-docs/version/0.23.4/whatsnew.html#rename-reindex-now-also-accept-axis-keyword).

(I also fixed the assertEquals deprecation warnings while I was at it).